### PR TITLE
fix(auth): 🐛 infinite loop

### DIFF
--- a/app/frontend/src/features/auth/queries.ts
+++ b/app/frontend/src/features/auth/queries.ts
@@ -1,18 +1,11 @@
 import api from "@/lib/api";
-import type { User, UserProfile } from "@server/db/users";
 import { queryOptions } from "@tanstack/react-query";
-import { redirect } from "@tanstack/react-router";
 
-export const authQueryOptions = queryOptions<{
-	user: User;
-	profile: UserProfile;
-}>({
-	queryKey: [api.auth.$url().pathname],
+export const authQueryOptions = queryOptions({
+	queryKey: ["GET", api.auth.$url().pathname],
 	queryFn: async () => {
 		const response = await api.auth.$get();
-		if (!response.ok)
-			throw redirect({ to: "/signin", search: { from: location.href } });
-
+		if (response.status === 401) return null;
 		return (await response.json()).data;
 	},
 	staleTime: Number.POSITIVE_INFINITY,

--- a/app/frontend/src/routes/(auth)/signin.tsx
+++ b/app/frontend/src/routes/(auth)/signin.tsx
@@ -17,7 +17,7 @@ import { z } from "zod";
 export const Route = createFileRoute("/(auth)/signin")({
 	ssr: true,
 	validateSearch: z.object({
-		from: z.string().url().nullish(),
+		from: z.string().url().optional(),
 	}),
 	beforeLoad: async ({ context: { queryClient } }) => {
 		if (await queryClient.ensureQueryData(authQueryOptions))


### PR DESCRIPTION
This pull request includes changes to the authentication query options and the validation schema for the sign-in route. The most important changes are as follows:

Improvements to authentication query options:

* [`app/frontend/src/features/auth/queries.ts`](diffhunk://#diff-c0ef6e6470c74fc721eb4ea195a6ee3733a325ceb51ab3a349d130ce179ad816L2-R8): Modified the `authQueryOptions` to use a simplified query key format and handle unauthorized responses by returning null instead of redirecting.

Updates to validation schema:

* [`app/frontend/src/routes/(auth)/signin.tsx`](diffhunk://#diff-7b623f90b8c7c5049a4ae6f0b13e9ae43f9e4b351b50fe432742026dc01e371eL20-R20): Changed the `validateSearch` schema to use `optional` instead of `nullish` for the `from` parameter.